### PR TITLE
redefine L_alpha from Muv consistent with Claudia + Sean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+*.pyc
+*-checkpoint.ipynb


### PR DESCRIPTION
I rewrote the code in the `make_pL_Lya(` function to use Claudia's definition of L_alpha. This is exactly the same as ours (so no results change), but it's a lot simpler :)

p(L_alpha | Muv) = p(EW | Muv) * dEW/dL_alpha

<img width="573" alt="image" src="https://user-images.githubusercontent.com/5003032/96637511-c6185f80-12ec-11eb-86e2-9a7edc27370b.png">

